### PR TITLE
use low_memory option to avoid DType warning

### DIFF
--- a/api/parsers/csvparser.py
+++ b/api/parsers/csvparser.py
@@ -14,7 +14,7 @@ class CSVParser(Parser):
         self.initEntities()
 
     def parse(self,filename):
-        csv = read_csv(filename)
+        csv = read_csv(filename, low_memory=False)
         start_time = to_datetime(csv['timestamp'][0])
         time_delta = (to_datetime(csv['timestamp']) - start_time)
         seconds = time_delta / np.timedelta64(1, 's')


### PR DESCRIPTION
It's not efficient but will do for now.
Sometimes a CSV file can contain string and numbers and it's difficult for pandas to guess the type of each columns by looking at the first rows (a row can contain -1 and then string data, or even being empty).

So we use the low_memory=False option which will have to read the all file to guess the type of each columns.
Let see if we find a better way in the future.